### PR TITLE
Different method of importing css

### DIFF
--- a/keats-frontend.html
+++ b/keats-frontend.html
@@ -8,13 +8,13 @@
 
 	function loadCSS(location){
 		console.log('loading css');
-		$("head").append("<link>");
-		var css = $("head").children(":last");
-		css.attr({
-		      rel:  "stylesheet",
-		      type: "text/css",
-		   href: location
-		});
+		var head = document.getElementsByTagName('head')[0],
+   		link = document.createElement('link');
+		link.type = 'text/css';
+   		link.rel = 'stylesheet';
+   		link.href = url;
+   		head.appendChild(link);
+   		return link;
 	}
 </script>
 

--- a/keats-frontend.html
+++ b/keats-frontend.html
@@ -6,7 +6,7 @@
 	// LOCAL
 	loadCSS("theme.css");
 
-	function loadCSS(location){
+	function loadCSS(url){
 		console.log('loading css');
 		var head = document.getElementsByTagName('head')[0],
    		link = document.createElement('link');


### PR DESCRIPTION
The existing method replaces the arrows in the breadcrumbs and the plus/minus signs in the accordion menus with little boxes; I think there's a conflict there. This method seems to work without conflict as far as I have tested.